### PR TITLE
Fix code scanning alert no. 1: Regular expression injection

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "@semantic-release/commit-analyzer": "^8.0.1",
     "@semantic-release/release-notes-generator": "^9.0.1",
     "conventional-changelog-conventionalcommits": "^4.6.1",
-    "semver": "^7.3.5"
+    "semver": "^7.3.5",
+    "lodash": "^4.17.21"
   },
   "devDependencies": {
     "@octokit/rest": "^18.12.0",

--- a/src/action.ts
+++ b/src/action.ts
@@ -14,6 +14,7 @@ import {
 } from './utils';
 import { createTag } from './github';
 import { Await } from './ts';
+import _ from 'lodash';
 
 export default async function main() {
   const defaultBump = core.getInput('default_bump') as ReleaseType | 'false';
@@ -67,7 +68,8 @@ export default async function main() {
     appendToPreReleaseTag ? appendToPreReleaseTag : currentBranch
   ).replace(/[^a-zA-Z0-9-]/g, '-');
 
-  const prefixRegex = new RegExp(`^${tagPrefix}`);
+  const safeTagPrefix = _.escapeRegExp(tagPrefix);
+  const prefixRegex = new RegExp(`^${safeTagPrefix}`);
 
   const validTags = await getValidTags(
     prefixRegex,


### PR DESCRIPTION
Fixes [https://github.com/sede-open/github-tag-action/security/code-scanning/1](https://github.com/sede-open/github-tag-action/security/code-scanning/1)

To fix the problem, we need to sanitize the `tagPrefix` input before using it in the regular expression. The best way to do this is by using a sanitization function such as `_.escapeRegExp` from the lodash library. This function escapes special characters in the input that have special meaning in regular expressions, thus preventing injection attacks.

- Add the lodash library to the project if it is not already included.
- Import the `_.escapeRegExp` function from lodash.
- Use `_.escapeRegExp` to sanitize the `tagPrefix` input before constructing the regular expression.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
